### PR TITLE
Loading the schema as first thing. 

### DIFF
--- a/packager/packager.go
+++ b/packager/packager.go
@@ -1,0 +1,27 @@
+package packager
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+var schemaDescriptor = make(map[string]interface{})
+
+const schemaPath = "schema.json"
+
+func init() {
+	f, err := os.Open(schemaPath)
+	if err != nil {
+		log.Fatalf("Error trying to open the schema descriptor: %q", err)
+	}
+	defer f.Close()
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		log.Fatalf("Error trying to read the schema descriptor: %q", err)
+	}
+	if err := json.Unmarshal(b, &schemaDescriptor); err != nil {
+		log.Fatalf("Error trying to unmarshal the schema descriptor: %q", err)
+	}
+}

--- a/packager/packager_test.go
+++ b/packager/packager_test.go
@@ -1,0 +1,11 @@
+package packager
+
+import (
+	"testing"
+)
+
+func TestInit(t *testing.T) {
+	if _, ok := schemaDescriptor["fields"]; !ok {
+		t.Errorf("schema expected to have fields.")
+	}
+}


### PR DESCRIPTION
Storing it in a package variable because the schema won't change during the service lifecycle