### PR TITLE
Uploads files to pcloud and generates a public URL to them

### DIFF
--- a/store/client.go
+++ b/store/client.go
@@ -48,7 +48,11 @@ func authenticate(c *http.Client, username string, password string) (string, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		dump, _ := httputil.DumpResponse(resp, true)
+		dump, err := httputil.DumpResponse(resp, true)
+
+		if err != nil {
+			return "", fmt.Errorf("Server responded with non 200 (OK) status code. Response failed to dump")
+		}
 
 		return "", fmt.Errorf("Server responded with a non 200 (OK) status code. Response dump: \n\n%s", string(dump))
 	}
@@ -117,7 +121,11 @@ func uploadFile(pcloud *PCloudClient, filename string, r io.Reader) (int, error)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		dump, _ := httputil.DumpResponse(resp, true)
+		dump, err := httputil.DumpResponse(resp, true)
+
+		if err != nil {
+			return 0, fmt.Errorf("Server responded with non 200 (OK) status code. Response failed to dump")
+		}
 
 		return 0, fmt.Errorf("Server responded with a non 200 (OK) status code. Response dump: \n\n%s", string(dump))
 	}
@@ -137,7 +145,12 @@ func uploadFile(pcloud *PCloudClient, filename string, r io.Reader) (int, error)
 	}
 
 	if len(jsonResp.Fileids) != 1 {
-		dump, _ := httputil.DumpResponse(resp, true)
+		dump, err := httputil.DumpResponse(resp, true)
+
+		if err != nil {
+			return 0, fmt.Errorf("Server responded with non 200 (OK) status code. Response failed to dump")
+		}
+
 		return 0, fmt.Errorf("Something went wrong. We could not fill get the fileids from the response. Response was: \n\n%s", string(dump))
 	}
 
@@ -158,7 +171,11 @@ func generatePublicLink(pcloud *PCloudClient, fileID int) (string, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		dump, _ := httputil.DumpResponse(resp, true)
+		dump, err := httputil.DumpResponse(resp, true)
+
+		if err != nil {
+			return "", fmt.Errorf("Server responded with non 200 (OK) status code. Response failed to dump")
+		}
 
 		return "", fmt.Errorf("Server responded with a non 200 (OK) status code. Response dump: \n\n%s", string(dump))
 	}
@@ -178,7 +195,12 @@ func generatePublicLink(pcloud *PCloudClient, fileID int) (string, error) {
 	}
 
 	if jsonResp.Link == "" {
-		dump, _ := httputil.DumpResponse(resp, true)
+		dump, err := httputil.DumpResponse(resp, true)
+
+		if err != nil {
+			return "", fmt.Errorf("Server responded with non 200 (OK) status code. Response failed to dump")
+		}
+
 		return "", fmt.Errorf("Something went wrong when generating the public link. Response was: \n\n%s", string(dump))
 	}
 

--- a/store/client.go
+++ b/store/client.go
@@ -1,12 +1,16 @@
 package store
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 )
 
 // PCloudClient represents the PCloud client instance to interact with PCLoud API.
@@ -18,6 +22,16 @@ type PCloudClient struct {
 // authResponse; internal representation of the auth response. Will be used to Unmarshal the response
 type authResponse struct {
 	Auth string
+}
+
+// uploadFileResponse; internal representation of the upload file response.
+type uploadFileResponse struct {
+	Fileids []int
+}
+
+// generateLinkResponse; internal representation of the public link response generation.
+type generateLinkResponse struct {
+	Link string
 }
 
 // authenticate; sends the HTTP request to authenticate with PCloud using provided credentials.
@@ -60,6 +74,111 @@ func authenticate(c *http.Client, username string, password string) (string, err
 	return jsonResponse.Auth, err
 }
 
+// uploadFile; Uploads files to the PCloud API, returning the fileID.
+func uploadFile(pcloud *PCloudClient, filename string, r io.Reader) (int, error) {
+	URL := buildPCLoudURL("uploadfile", url.Values{
+		"auth": {pcloud.Token},
+		// We are always going to upload in the root.
+		"path":     {"/"},
+		"filename": {filename},
+	})
+
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+
+	fw, err := w.CreateFormFile(filename, filename)
+
+	if err != nil {
+		return 0, err
+	}
+
+	if _, err := io.Copy(fw, r); err != nil {
+		return 0, err
+	}
+
+	if err := w.Close(); err != nil {
+		return 0, err
+	}
+
+	req, err := http.NewRequest("POST", URL, &b)
+
+	if err != nil {
+		return 0, err
+	}
+
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := pcloud.Client.Do(req)
+
+	if err != nil {
+		return 0, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := httputil.DumpResponse(resp, true)
+
+		return 0, fmt.Errorf("Server responded with a non 200 (OK) status code. Response dump: \n\n%s", string(dump))
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		return 0, err
+	}
+
+	jsonResp := uploadFileResponse{}
+
+	if err := json.Unmarshal(data, &jsonResp); err != nil {
+		return 0, err
+	}
+
+	if len(jsonResp.Fileids) != 1 {
+		dump, _ := httputil.DumpResponse(resp, true)
+		return 0, fmt.Errorf("Something went wrong. We could not fill get the fileids from the response. Response was: \n\n%s", string(dump))
+	}
+
+	return jsonResp.Fileids[0], nil
+}
+
+// generatePublicLink; generates a public link to a file it uploaded.
+func generatePublicLink(pcloud *PCloudClient, fileID int) (string, error) {
+	URL := buildPCLoudURL("getfilepublink", url.Values{
+		"auth":   {pcloud.Token},
+		"fileid": {strconv.Itoa(fileID)},
+	})
+
+	resp, err := pcloud.Client.Get(URL)
+
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := httputil.DumpResponse(resp, true)
+
+		return "", fmt.Errorf("Server responded with a non 200 (OK) status code. Response dump: \n\n%s", string(dump))
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		return "", err
+	}
+
+	jsonResp := generateLinkResponse{}
+
+	if err := json.Unmarshal(data, &jsonResp); err != nil {
+		return "", err
+	}
+
+	if jsonResp.Link == "" {
+		dump, _ := httputil.DumpResponse(resp, true)
+		return "", fmt.Errorf("Something went wrong when generating the public link. Response was: \n\n%s", string(dump))
+	}
+
+	return jsonResp.Link, nil
+}
+
 // NewPCloudClient returns the PCloudClient to interact with PCloudAPI, or error in case using wrong credentials.
 func NewPCloudClient(username string, password string) (*PCloudClient, error) {
 	c := &http.Client{}
@@ -73,4 +192,21 @@ func NewPCloudClient(username string, password string) (*PCloudClient, error) {
 
 	// PCloudClient the instance needs an HTTP client and the token.
 	return &PCloudClient{Client: c, Token: token}, nil
+}
+
+// Put receives filename and io.Reader, uploads the file and returns a public link.
+func (pcloud *PCloudClient) Put(filename string, r io.Reader) (string, error) {
+	fileID, err := uploadFile(pcloud, filename, r)
+
+	if err != nil {
+		return "", err
+	}
+
+	URL, err := generatePublicLink(pcloud, fileID)
+
+	if err != nil {
+		return "", err
+	}
+
+	return URL, nil
 }

--- a/store/client.go
+++ b/store/client.go
@@ -60,6 +60,8 @@ func authenticate(c *http.Client, username string, password string) (string, err
 		return "", err
 	}
 
+	defer resp.Body.Close()
+
 	// We are going to use this struct to Unmarshal the JSON response from PCloud.
 	jsonResponse := authResponse{}
 
@@ -126,6 +128,8 @@ func uploadFile(pcloud *PCloudClient, filename string, r io.Reader) (int, error)
 		return 0, err
 	}
 
+	defer resp.Body.Close()
+
 	jsonResp := uploadFileResponse{}
 
 	if err := json.Unmarshal(data, &jsonResp); err != nil {
@@ -164,6 +168,8 @@ func generatePublicLink(pcloud *PCloudClient, fileID int) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	defer resp.Body.Close()
 
 	jsonResp := generateLinkResponse{}
 

--- a/store/client_test.go
+++ b/store/client_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -154,5 +155,157 @@ func TestAuthenticationFailsWhenResponseIsNot200OK(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "HTTP/0.0 500 Internal Server Error") {
 		t.Error("Failed to dump the response")
+	}
+}
+
+func successUploadFileResponse(fileID int) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		// Send response to be tested
+		Body: ioutil.NopCloser(bytes.NewBufferString(fmt.Sprintf("{\"fileids\": [%d]}", fileID))),
+		// Must be set to non-nil value or it panics
+		Header: make(http.Header),
+	}
+}
+
+func successUploadedFileLinkResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		// Send response to be tested
+		Body: ioutil.NopCloser(bytes.NewBufferString(`{"link": "https://my.pcloud.com/#page=publink&code=LinkCode"}`)),
+		// Must be set to non-nil value or it panics
+		Header: make(http.Header),
+	}
+}
+
+func TestCreatesFileOnPCloud(t *testing.T) {
+	fakeToken := "fakeToken"
+	filename := "loremipsum.txt"
+	fileID := 123
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+		uploadURL := buildPCLoudURL("uploadfile", url.Values{
+			"auth":     {fakeToken},
+			"path":     {"/"},
+			"filename": {filename},
+		})
+
+		if req.URL.String() == uploadURL {
+			return successUploadFileResponse(fileID)
+		}
+
+		generateLinkURL := buildPCLoudURL("getfilepublink", url.Values{
+			"auth":   {fakeToken},
+			"path":   {"/"},
+			"fileid": {string(fileID)},
+		})
+
+		if req.URL.String() == generateLinkURL {
+			return successUploadedFileLinkResponse()
+		}
+
+		t.Error("Unkown mocked request.")
+
+		return nil
+	})
+
+	pcloud := PCloudClient{Client: client, Token: fakeToken}
+
+	r := strings.NewReader("Works")
+
+	URL, _ := pcloud.Put(filename, r)
+
+	if URL != "https://my.pcloud.com/#page=publink&code=LinkCode" {
+		t.Error("Expected mocked public link doesnt exist")
+	}
+}
+
+func TestHandlesErrorWhenUploadFileFails(t *testing.T) {
+	fakeToken := "fakeToken"
+	filename := "loremipsum.txt"
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+		uploadURL := buildPCLoudURL("uploadfile", url.Values{
+			"auth":     {fakeToken},
+			"path":     {"/"},
+			"filename": {filename},
+		})
+
+		if req.URL.String() != uploadURL {
+			t.Error("Put is using the wrong URL.")
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewBufferString(`{
+				"error": "Something went wrong."
+			}`)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
+		}
+	})
+
+	pcloud := PCloudClient{Client: client, Token: fakeToken}
+
+	r := strings.NewReader("Works")
+
+	_, err := pcloud.Put(filename, r)
+
+	if err == nil {
+		t.Error("Expected error to be nil")
+	}
+}
+
+func TestHandlesPublicLinkGenerationFails(t *testing.T) {
+	fakeToken := "fakeToken"
+	filename := "loremipsum.txt"
+	fileID := 123
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+		uploadURL := buildPCLoudURL("uploadfile", url.Values{
+			"auth":     {fakeToken},
+			"path":     {"/"},
+			"filename": {filename},
+		})
+
+		if req.URL.String() == uploadURL {
+			return successUploadFileResponse(fileID)
+		}
+
+		generateLinkURL := buildPCLoudURL("getfilepublink", url.Values{
+			"auth":   {fakeToken},
+			"path":   {"/"},
+			"fileid": {string(fileID)},
+		})
+
+		if req.URL.String() == generateLinkURL {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				// Send response to be tested
+				Body: ioutil.NopCloser(bytes.NewBufferString(`{
+					"error": "Something went wrong."
+				}`)),
+				// Must be set to non-nil value or it panics
+				Header: make(http.Header),
+			}
+		}
+
+		t.Error("Unkown mocked request.")
+
+		return nil
+	})
+
+	pcloud := PCloudClient{Client: client, Token: fakeToken}
+
+	r := strings.NewReader("Works")
+
+	_, err := pcloud.Put(filename, r)
+
+	if err == nil {
+		t.Error("Expected error to be nil")
 	}
 }

--- a/store/client_test.go
+++ b/store/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -197,8 +198,7 @@ func TestCreatesFileOnPCloud(t *testing.T) {
 
 		generateLinkURL := buildPCLoudURL("getfilepublink", url.Values{
 			"auth":   {fakeToken},
-			"path":   {"/"},
-			"fileid": {string(fileID)},
+			"fileid": {strconv.Itoa(fileID)},
 		})
 
 		if req.URL.String() == generateLinkURL {
@@ -278,8 +278,7 @@ func TestHandlesPublicLinkGenerationFails(t *testing.T) {
 
 		generateLinkURL := buildPCLoudURL("getfilepublink", url.Values{
 			"auth":   {fakeToken},
-			"path":   {"/"},
-			"fileid": {string(fileID)},
+			"fileid": {strconv.Itoa(fileID)},
 		})
 
 		if req.URL.String() == generateLinkURL {


### PR DESCRIPTION
### Added

- Adds the `store.Put` method which receives a filename (string), and an `io.Reader` to the file handler, uploads it to the pcloud platform, and return the generated public URL.

---

Trello card: https://trello.com/c/GtyJODZ9/15-enviar-arquivo-zip-para-pcloud